### PR TITLE
Modify deployment for gke autopilot

### DIFF
--- a/deploy/deployment.yaml
+++ b/deploy/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
     app: app
   name: app
 spec:
-  replicas: 3
+  replicas: 1
   selector:
     matchLabels:
       app: app
@@ -15,21 +15,14 @@ spec:
       labels:
         app: app
     spec:
-      tolerations:
-      - key: dedicated
-        operator: Equal
-        value: uniqpanel
-        effect: NoSchedule
-      nodeSelector:
-          dedicated: uniqpanel
       containers:
         - name: app
           resources:
             requests:
-              cpu: "0.5"
+              cpu: "250m"
               memory: "245Mi"
             limits:
-              cpu: "2"
+              cpu: "1"
               memory: "1G"
           env:
             - name: PORT
@@ -53,6 +46,20 @@ spec:
       restartPolicy: Always
 
 ---
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: app
+spec:
+  maxReplicas: 3
+  minReplicas: 1
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: app
+  targetCPUUtilizationPercentage: 50
+
+---
 apiVersion: v1
 kind: Service
 metadata:
@@ -72,7 +79,7 @@ metadata:
     app: nginx
   name: nginx
 spec:
-  replicas: 3
+  replicas: 1
   selector:
     matchLabels:
       app: nginx
@@ -81,21 +88,14 @@ spec:
       labels:
         app: nginx
     spec:
-      tolerations:
-      - key: dedicated
-        operator: Equal
-        value: uniqpanel
-        effect: NoSchedule
-      nodeSelector:
-          dedicated: uniqpanel
       containers:
         - name: nginx
           resources:
             requests:
-              cpu: "0.5"
+              cpu: "250m"
               memory: "245Mi"
             limits:
-              cpu: "2"
+              cpu: "1"
               memory: "1G"
           env:
             - name: NGINX_PROXY_PASS
@@ -107,6 +107,20 @@ spec:
           image: us.gcr.io/kizuna-188702/github.com/austinpray/uniqpanel/nginx:PLACEHOLDER
           imagePullPolicy: Always
       restartPolicy: Always
+
+---
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: nginx
+spec:
+  maxReplicas: 3
+  minReplicas: 1
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: nginx
+  targetCPUUtilizationPercentage: 50
 
 ---
 apiVersion: networking.gke.io/v1
@@ -127,6 +141,7 @@ metadata:
     app: "nginx"
   annotations:
     cloud.google.com/backend-config: '{"default": "nginx-backendconfig"}'
+    networking.gke.io/v1beta1.FrontendConfig: "nginx-frontendconfig"
 spec:
   ports:
   - protocol: "TCP"
@@ -147,6 +162,15 @@ spec:
     drainingTimeoutSec: 60
 
 ---
+apiVersion: networking.gke.io/v1beta1
+kind: FrontendConfig
+metadata:
+  name: nginx-frontendconfig
+spec:
+  redirectToHttps:
+    enabled: true
+
+---
 apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
@@ -159,3 +183,4 @@ spec:
   backend:
     serviceName: nginx
     servicePort: 80
+


### PR DESCRIPTION
[GKE autopilot](https://cloud.google.com/kubernetes-engine/docs/concepts/autopilot-overview) bills you by the pod. This app is on ice, so:

- lower resource requests
- HPA

Result is cheep hosting:
![image](https://user-images.githubusercontent.com/2192970/110833436-0bb8d300-8262-11eb-8264-ddb071d30ff3.png)